### PR TITLE
devise_create_usersから余計なカンマを削除

### DIFF
--- a/db/migrate/20210120080447_devise_create_users.rb
+++ b/db/migrate/20210120080447_devise_create_users.rb
@@ -11,7 +11,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       t.string :first_name_kanji,   null: false, default: ""
       t.string :family_name_kana,   null: false, default: ""
       t.string :first_name_kana,    null: false, default: ""
-      t.date   :birthday,           null: false, 
+      t.date   :birthday,           null: false
       t.text   :profile
 
 


### PR DESCRIPTION
# What
余計なカンマの削除

# Why
syntax errorを起こしていたため